### PR TITLE
Render the quantity overlay for open and closed coal bags and fix empty bag message capturing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,15 +10,15 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.17'
+def runeLiteVersion = '1.7.23'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.4'
-	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compileOnly 'org.projectlombok:lombok:1.18.20'
+	annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
-	testImplementation 'junit:junit:4.12'
+	testImplementation 'junit:junit:4.13.2'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 }
 

--- a/src/main/java/com/coalbagplugin/CoalBag.java
+++ b/src/main/java/com/coalbagplugin/CoalBag.java
@@ -70,14 +70,13 @@ public class CoalBag
 			final Matcher oneOrManyMatcher = BAG_ONE_OR_MANY_MESSAGE.matcher(message);
 			if (oneOrManyMatcher.matches())
 			{
-				// grabs the amount of coal in the bag from the message, turns it into an integer, and passes it into the coal bag amount
 				final String match = oneOrManyMatcher.group(1);
-				int num = 1;
-				if (!"one".equals(match))
+				if (match.equals("one"))
 				{
-					num = Integer.parseInt(match);
+					setAmount(1);
+				} else {
+					setAmount(Integer.parseInt(match));
 				}
-				setAmount(num);
 			}
 		}
 	}

--- a/src/main/java/com/coalbagplugin/CoalBag.java
+++ b/src/main/java/com/coalbagplugin/CoalBag.java
@@ -28,7 +28,7 @@ package com.coalbagplugin;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CoalInBag
+public class CoalBag
 {
 	private static final int UNKNOWN_AMOUNT = -1;
 	private static final int EMPTY_AMOUNT = 0;

--- a/src/main/java/com/coalbagplugin/CoalBagConfig.java
+++ b/src/main/java/com/coalbagplugin/CoalBagConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019 Adam <Adam@sigterm.info>
+ * Copyright (c) 2021 Nick Wolff <nick@wolff.tech>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.coalbagplugin;
+
+import net.runelite.client.config.Alpha;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+import java.awt.Color;
+
+@ConfigGroup("coalbag")
+public interface CoalBagConfig extends Config
+{
+	@Alpha
+	@ConfigItem(
+			keyName = "knownCoalBagColor",
+			name = "Filled Color",
+			description = "Configures the text color when there is an known quantity of coal in the coal bag",
+			position = 1
+	)
+	default Color knownCoalBagColor()
+	{
+		return Color.CYAN;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "emptyCoalBagColor",
+			name = "Empty Color",
+			description = "Configures the text color when 0 coal is in the coal bag",
+			position = 2
+	)
+	default Color emptyCoalBagColor()
+	{
+		return Color.RED;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "unknownCoalBagColor",
+			name = "Unknown Color",
+			description = "Configures the text color when there is an unknown quantity of coal in the coal bag",
+			position = 3
+	)
+	default Color unknownCoalBagColor()
+	{
+		return Color.GRAY;
+	}
+}

--- a/src/main/java/com/coalbagplugin/CoalBagOverlay.java
+++ b/src/main/java/com/coalbagplugin/CoalBagOverlay.java
@@ -25,10 +25,12 @@
  */
 package com.coalbagplugin;
 
+import com.google.common.collect.ImmutableList;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.util.Collection;
 import javax.inject.Inject;
 import net.runelite.api.ItemID;
 import net.runelite.api.widgets.WidgetItem;
@@ -37,13 +39,21 @@ import net.runelite.client.ui.overlay.components.TextComponent;
 
 public class CoalBagOverlay extends WidgetItemOverlay
 {
+	private static final Collection<Integer> COAL_BAG_IDS = ImmutableList.of(
+			ItemID.OPEN_COAL_BAG,
+			ItemID.COAL_BAG,
+			ItemID.COAL_BAG_12019,
+			ItemID.COAL_BAG_25627
+	);
+
 	@Inject
 	CoalBagOverlay() { showOnInventory(); }
 
 	@Override
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem itemWidget)
 	{
-		if (itemId == ItemID.COAL_BAG_12019 || itemId == ItemID.COAL_BAG)
+
+		if (COAL_BAG_IDS.contains(itemId))
 		{
 			final Rectangle bounds = itemWidget.getCanvasBounds();
 			final TextComponent textComponent = new TextComponent();

--- a/src/main/java/com/coalbagplugin/CoalBagOverlay.java
+++ b/src/main/java/com/coalbagplugin/CoalBagOverlay.java
@@ -64,12 +64,12 @@ public class CoalBagOverlay extends WidgetItemOverlay
 			final TextComponent textComponent = new TextComponent();
 			textComponent.setPosition(new Point(bounds.x - 1, bounds.y + 8));
 
-			if (CoalInBag.isUnknown())
+			if (CoalBag.isUnknown())
 			{
 				textComponent.setColor(config.unknownCoalBagColor());
 				textComponent.setText("?");
 			}
-			else if (CoalInBag.isEmpty())
+			else if (CoalBag.isEmpty())
 			{
 				textComponent.setColor(config.emptyCoalBagColor());
 				textComponent.setText("0");
@@ -77,7 +77,7 @@ public class CoalBagOverlay extends WidgetItemOverlay
 			else
 			{
 				textComponent.setColor(config.knownCoalBagColor());
-				textComponent.setText(CoalInBag.getAmount());
+				textComponent.setText(CoalBag.getAmount());
 			}
 
 			textComponent.render(graphics);

--- a/src/main/java/com/coalbagplugin/CoalBagOverlay.java
+++ b/src/main/java/com/coalbagplugin/CoalBagOverlay.java
@@ -40,10 +40,10 @@ import net.runelite.client.ui.overlay.components.TextComponent;
 public class CoalBagOverlay extends WidgetItemOverlay
 {
 	private static final Collection<Integer> COAL_BAG_IDS = ImmutableList.of(
-			ItemID.OPEN_COAL_BAG,
-			ItemID.COAL_BAG,
-			ItemID.COAL_BAG_12019,
-			ItemID.COAL_BAG_25627
+		ItemID.OPEN_COAL_BAG,
+		ItemID.COAL_BAG,
+		ItemID.COAL_BAG_12019,
+		ItemID.COAL_BAG_25627
 	);
 
 	@Inject

--- a/src/main/java/com/coalbagplugin/CoalBagOverlay.java
+++ b/src/main/java/com/coalbagplugin/CoalBagOverlay.java
@@ -58,16 +58,18 @@ public class CoalBagOverlay extends WidgetItemOverlay
 			final Rectangle bounds = itemWidget.getCanvasBounds();
 			final TextComponent textComponent = new TextComponent();
 			textComponent.setPosition(new Point(bounds.x - 1, bounds.y + 8));
-			textComponent.setColor(Color.CYAN);
 
-			if (CoalInBag.isUnknown())
-			{
+			if (CoalInBag.isUnknown()) {
+				textComponent.setColor(Color.GRAY);
 				textComponent.setText("?");
-			}
-			else
-			{
+			} else if (CoalInBag.isEmpty()) {
+				textComponent.setColor(Color.RED);
+				textComponent.setText("0");
+			} else {
+				textComponent.setColor(Color.CYAN);
 				textComponent.setText(CoalInBag.tellAmount());
 			}
+
 			textComponent.render(graphics);
 		}
 	}

--- a/src/main/java/com/coalbagplugin/CoalBagOverlay.java
+++ b/src/main/java/com/coalbagplugin/CoalBagOverlay.java
@@ -26,28 +26,33 @@
 package com.coalbagplugin;
 
 import com.google.common.collect.ImmutableList;
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.util.Collection;
-import javax.inject.Inject;
 import net.runelite.api.ItemID;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 import net.runelite.client.ui.overlay.components.TextComponent;
 
+import javax.inject.Inject;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.Point;
+import java.util.Collection;
+
 public class CoalBagOverlay extends WidgetItemOverlay
 {
+	private final CoalBagConfig config;
 	private static final Collection<Integer> COAL_BAG_IDS = ImmutableList.of(
-		ItemID.OPEN_COAL_BAG,
-		ItemID.COAL_BAG,
-		ItemID.COAL_BAG_12019,
-		ItemID.COAL_BAG_25627
+			ItemID.OPEN_COAL_BAG,
+			ItemID.COAL_BAG,
+			ItemID.COAL_BAG_12019,
+			ItemID.COAL_BAG_25627
 	);
 
 	@Inject
-	CoalBagOverlay() { showOnInventory(); }
+	private CoalBagOverlay(CoalBagConfig config)
+	{
+		this.config = config;
+		showOnInventory();
+	}
 
 	@Override
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem itemWidget)
@@ -59,14 +64,19 @@ public class CoalBagOverlay extends WidgetItemOverlay
 			final TextComponent textComponent = new TextComponent();
 			textComponent.setPosition(new Point(bounds.x - 1, bounds.y + 8));
 
-			if (CoalInBag.isUnknown()) {
-				textComponent.setColor(Color.GRAY);
+			if (CoalInBag.isUnknown())
+			{
+				textComponent.setColor(config.unknownCoalBagColor());
 				textComponent.setText("?");
-			} else if (CoalInBag.isEmpty()) {
-				textComponent.setColor(Color.RED);
+			}
+			else if (CoalInBag.isEmpty())
+			{
+				textComponent.setColor(config.emptyCoalBagColor());
 				textComponent.setText("0");
-			} else {
-				textComponent.setColor(Color.CYAN);
+			}
+			else
+			{
+				textComponent.setColor(config.knownCoalBagColor());
 				textComponent.setText(CoalInBag.tellAmount());
 			}
 

--- a/src/main/java/com/coalbagplugin/CoalBagOverlay.java
+++ b/src/main/java/com/coalbagplugin/CoalBagOverlay.java
@@ -77,7 +77,7 @@ public class CoalBagOverlay extends WidgetItemOverlay
 			else
 			{
 				textComponent.setColor(config.knownCoalBagColor());
-				textComponent.setText(CoalInBag.tellAmount());
+				textComponent.setText(CoalInBag.getAmount());
 			}
 
 			textComponent.render(graphics);

--- a/src/main/java/com/coalbagplugin/CoalBagPlugin.java
+++ b/src/main/java/com/coalbagplugin/CoalBagPlugin.java
@@ -69,7 +69,7 @@ public class CoalBagPlugin extends Plugin
 	protected void startUp()
 	{
 		overlayManager.add(coalBagOverlay);
-		CoalInBag.setUnknownAmount();
+		CoalBag.setUnknownAmount();
 	}
 
 	@Override
@@ -83,7 +83,7 @@ public class CoalBagPlugin extends Plugin
 	{
 		if (event.getType() == ChatMessageType.GAMEMESSAGE)
 		{
-			CoalInBag.updateAmount(event.getMessage());
+			CoalBag.updateAmount(event.getMessage());
 		}
 	}
 
@@ -94,7 +94,7 @@ public class CoalBagPlugin extends Plugin
 		Widget coalBagWidget = client.getWidget(12648450);
 		if (coalBagWidget != null)
 		{
-			CoalInBag.updateAmount(coalBagWidget.getText());
+			CoalBag.updateAmount(coalBagWidget.getText());
 		}
 	}
 
@@ -103,7 +103,7 @@ public class CoalBagPlugin extends Plugin
 	{
 		if ("Destroy".equals(event.getMenuOption()))
 		{
-			CoalInBag.setUnknownAmount();
+			CoalBag.setUnknownAmount();
 		}
 	}
 }

--- a/src/main/java/com/coalbagplugin/CoalBagPlugin.java
+++ b/src/main/java/com/coalbagplugin/CoalBagPlugin.java
@@ -40,8 +40,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Slf4j
 @PluginDescriptor(
@@ -51,13 +49,6 @@ import java.util.regex.Pattern;
 )
 public class CoalBagPlugin extends Plugin
 {
-	private static final String BAG_EMPTY_MESSAGE = "The coal bag is empty.";
-	private static final String BAG_EMPTY_MESSAGE_NOW = "The coal bag is now empty.";
-	private static final String BAG_ONE_MESSAGE = "The coal bag contains one piece of coal.";
-	private static final String BAG_ONE_MESSAGE_WIDGET = "The coal bag still contains one piece of coal.";
-	// this regex is used to match coal bag messages and extract the amount of coal from the message
-	private static final Pattern BAG_MANY_MESSAGE = Pattern.compile("^The coal bag contains ([\\d]+)? pieces? of coal\\.$");
-	private static final Pattern BAG_MANY_MESSAGE_WIDGET = Pattern.compile("^The coal bag still contains ([\\d]+)? pieces? of coal\\.");
 
 	@Inject
 	private Client client;
@@ -78,8 +69,7 @@ public class CoalBagPlugin extends Plugin
 	protected void startUp()
 	{
 		overlayManager.add(coalBagOverlay);
-		// sets the coal bag overlay to unknown
-		CoalInBag.updateAmount(-1);
+		CoalInBag.setUnknownAmount();
 	}
 
 	@Override
@@ -93,24 +83,7 @@ public class CoalBagPlugin extends Plugin
 	{
 		if (event.getType() == ChatMessageType.GAMEMESSAGE)
 		{
-			switch (event.getMessage())
-			{
-				case BAG_EMPTY_MESSAGE:
-				case BAG_EMPTY_MESSAGE_NOW:
-					CoalInBag.updateAmount(0);
-					break;
-				case BAG_ONE_MESSAGE:
-					CoalInBag.updateAmount(1);
-					break;
-				default:
-					Matcher matcher = BAG_MANY_MESSAGE.matcher(event.getMessage());
-					if (matcher.matches())
-					{
-						// grabs the amount of coal in the bag from the message, turns it into an integer, and passes it into the coal bag amount
-						final int num = Integer.parseInt(matcher.group(1));
-						CoalInBag.updateAmount((num));
-					}
-			}
+			CoalInBag.updateAmount(event.getMessage());
 		}
 	}
 
@@ -119,29 +92,9 @@ public class CoalBagPlugin extends Plugin
 	{
 		// because the coal bag sometimes displays the emptied amount message as a widget, we need to check for that here
 		Widget coalBagWidget = client.getWidget(12648450);
-
 		if (coalBagWidget != null)
 		{
-			String widgetText = coalBagWidget.getText();
-			switch (widgetText)
-			{
-				case BAG_EMPTY_MESSAGE:
-				case BAG_EMPTY_MESSAGE_NOW:
-					CoalInBag.updateAmount(0);
-					break;
-				// the message for "one piece of coal remaining" in the widget is different than what is displayed in the chat
-				case BAG_ONE_MESSAGE_WIDGET:
-					CoalInBag.updateAmount(1);
-					break;
-				default:
-					// the widget id is shared with other widgets, so we need to check to see if the text is for the coal bag or not
-					Matcher matcher = BAG_MANY_MESSAGE_WIDGET.matcher(widgetText);
-					if (matcher.matches())
-					{
-						final int num = Integer.parseInt(matcher.group(1));
-						CoalInBag.updateAmount((num));
-					}
-			}
+			CoalInBag.updateAmount(coalBagWidget.getText());
 		}
 	}
 
@@ -150,7 +103,7 @@ public class CoalBagPlugin extends Plugin
 	{
 		if ("Destroy".equals(event.getMenuOption()))
 		{
-			CoalInBag.updateAmount(-1);
+			CoalInBag.setUnknownAmount();
 		}
 	}
 }

--- a/src/main/java/com/coalbagplugin/CoalBagPlugin.java
+++ b/src/main/java/com/coalbagplugin/CoalBagPlugin.java
@@ -25,9 +25,7 @@
  */
 package com.coalbagplugin;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.inject.Inject;
+import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -35,16 +33,21 @@ import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
+import javax.inject.Inject;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 @Slf4j
 @PluginDescriptor(
-	name = "Coal Bag",
-	description = "Shows how much coal is in the coal bag.",
-	tags = {"coal", "bag"}
+		name = "Coal Bag",
+		description = "Shows how much coal is in the coal bag.",
+		tags = {"coal", "bag"}
 )
 public class CoalBagPlugin extends Plugin
 {
@@ -65,6 +68,12 @@ public class CoalBagPlugin extends Plugin
 	@Inject
 	private CoalBagOverlay coalBagOverlay;
 
+	@Provides
+	CoalBagConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(CoalBagConfig.class);
+	}
+
 	@Override
 	protected void startUp()
 	{
@@ -80,9 +89,12 @@ public class CoalBagPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onChatMessage(ChatMessage event) {
-        if (event.getType() == ChatMessageType.GAMEMESSAGE) {
-			switch (event.getMessage()) {
+	public void onChatMessage(ChatMessage event)
+	{
+		if (event.getType() == ChatMessageType.GAMEMESSAGE)
+		{
+			switch (event.getMessage())
+			{
 				case BAG_EMPTY_MESSAGE:
 				case BAG_EMPTY_MESSAGE_NOW:
 					CoalInBag.updateAmount(0);
@@ -92,13 +104,14 @@ public class CoalBagPlugin extends Plugin
 					break;
 				default:
 					Matcher matcher = BAG_MANY_MESSAGE.matcher(event.getMessage());
-					if (matcher.matches()) {
+					if (matcher.matches())
+					{
 						// grabs the amount of coal in the bag from the message, turns it into an integer, and passes it into the coal bag amount
 						final int num = Integer.parseInt(matcher.group(1));
 						CoalInBag.updateAmount((num));
 					}
 			}
-        }
+		}
 	}
 
 	@Subscribe
@@ -106,10 +119,12 @@ public class CoalBagPlugin extends Plugin
 	{
 		// because the coal bag sometimes displays the emptied amount message as a widget, we need to check for that here
 		Widget coalBagWidget = client.getWidget(12648450);
+
 		if (coalBagWidget != null)
 		{
 			String widgetText = coalBagWidget.getText();
-			switch (widgetText) {
+			switch (widgetText)
+			{
 				case BAG_EMPTY_MESSAGE:
 				case BAG_EMPTY_MESSAGE_NOW:
 					CoalInBag.updateAmount(0);
@@ -121,7 +136,8 @@ public class CoalBagPlugin extends Plugin
 				default:
 					// the widget id is shared with other widgets, so we need to check to see if the text is for the coal bag or not
 					Matcher matcher = BAG_MANY_MESSAGE_WIDGET.matcher(widgetText);
-					if (matcher.matches()) {
+					if (matcher.matches())
+					{
 						final int num = Integer.parseInt(matcher.group(1));
 						CoalInBag.updateAmount((num));
 					}

--- a/src/main/java/com/coalbagplugin/CoalInBag.java
+++ b/src/main/java/com/coalbagplugin/CoalInBag.java
@@ -43,4 +43,9 @@ public class CoalInBag
 	{
 		return storedAmount < 0;
 	}
+
+	public static boolean isEmpty()
+	{
+		return storedAmount == 0;
+	}
 }

--- a/src/main/java/com/coalbagplugin/CoalInBag.java
+++ b/src/main/java/com/coalbagplugin/CoalInBag.java
@@ -25,27 +25,70 @@
  */
 package com.coalbagplugin;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class CoalInBag
 {
+	private static final int UNKNOWN_AMOUNT = -1;
+	private static final int EMPTY_AMOUNT = 0;
+
+	private static final Pattern BAG_EMPTY_MESSAGE = Pattern.compile("^The coal bag is (?:now\\s)?empty\\.");
+	private static final Pattern BAG_ONE_OR_MANY_MESSAGE = Pattern.compile("^The coal bag (?:still\\s)?contains ([\\d]+|one) pieces? of coal\\.");
+
 	private static int storedAmount;
 
-	public static String tellAmount()
+	private static void setAmount(int amount)
+	{
+		storedAmount = amount;
+	}
+
+	private static void setEmptyAmount()
+	{
+		storedAmount = EMPTY_AMOUNT;
+	}
+
+	public static void setUnknownAmount()
+	{
+		storedAmount = UNKNOWN_AMOUNT;
+	}
+
+	public static String getAmount()
 	{
 		return String.valueOf(storedAmount);
 	}
 
-	public static void updateAmount(int stored)
+	public static void updateAmount(String message)
 	{
-		storedAmount = stored;
+		final Matcher emptyMatcher = BAG_EMPTY_MESSAGE.matcher(message);
+		if (emptyMatcher.matches())
+		{
+			setEmptyAmount();
+		}
+		else
+		{
+			final Matcher oneOrManyMatcher = BAG_ONE_OR_MANY_MESSAGE.matcher(message);
+			if (oneOrManyMatcher.matches())
+			{
+				// grabs the amount of coal in the bag from the message, turns it into an integer, and passes it into the coal bag amount
+				final String match = oneOrManyMatcher.group(1);
+				int num = 1;
+				if (!"one".equals(match))
+				{
+					num = Integer.parseInt(match);
+				}
+				setAmount(num);
+			}
+		}
 	}
 
 	public static boolean isUnknown()
 	{
-		return storedAmount < 0;
+		return storedAmount == UNKNOWN_AMOUNT;
 	}
 
 	public static boolean isEmpty()
 	{
-		return storedAmount == 0;
+		return storedAmount == EMPTY_AMOUNT;
 	}
 }


### PR DESCRIPTION
Hello,

Features added:
- Config Panel added for color configuration
- Empty coal bag quantity is colored RED by default
- Unknown coal bag quantity is colored GRAY by default

Bugs fixed:
- An empty coal chat message can be one of two different strings, both are evaluated now
- An empty coal widget message can be one of two different strings, both are evaluated now

Optimizations:
- Previous code path for chat message evaluation had repeated if conditionals that were mutually exclusive. Adjusted the conditionals to use two different regular expressions instead

Thanks!