### PR TITLE
Track coal mined into open bags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Coal Bag are documented in this file.
 
+## 1.6 - 2026-07-25
+
+### Added
+
+- Track coal mined directly into an open bag, eligible bonus ore, and bank container-emptying.
+
+Thanks to [nanopink](https://github.com/nanopink) for contributing this release.
+
 ## 1.5 - 2022-05-24
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 2-Clause License
 
 Copyright (c) 2021, Nick Wolff
+Copyright (c) 2022, TicTac7x
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Coal Bag displays the amount of coal in your coal bag directly in your inventory
 - Displays the known coal amount on the coal bag.
 - Shows `0` when the bag is known to be empty.
 - Shows `?` when the amount is unknown.
+- Tracks coal mined directly into an open bag, including eligible bonus ore.
 - Provides configurable colors for known, empty, and unknown amounts.
 
 ## How It Works
 
-The counter updates when the game reports the coal bag's contents, such as when you check, fill, or empty the bag. The amount starts as unknown each time the plugin is enabled and remains unknown until the game reports the bag's contents.
+The counter updates when the game reports the coal bag's contents, such as when you check, fill, or empty the bag. Once known, the counter also follows coal mined directly into an open bag, bonus ore from the Celestial ring and Varrock platebody, and bank container-emptying.
 
-Coal added automatically while mining with an open coal bag is not currently tracked. Check the bag to update the counter after mining this way.
-
+Coal picked up from the ground directly into an open bag cannot be tracked reliably because the game does not expose a safe event for that action.
 ## Configuration
 
 The following counter colors can be configured in RuneLite:
@@ -37,6 +37,8 @@ If you encounter a problem, [open an issue](https://github.com/WolffTech/coal-ba
 ## Credits
 
 Coal Bag is based on Adam's [Essence Pouch plugin](https://github.com/Adam-/runelite-plugins/blob/esspouch/src/main/java/info/sigterm/plugins/esspouch/EssPouchPlugin.java).
+
+Automatic update handling is adapted from [Item Charges Improved](https://github.com/TicTac7x/runelite-plugins/tree/plugin-charges).
 
 ## Project Information
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Coal Bag displays the amount of coal in your coal bag directly in your inventory
 The counter updates when the game reports the coal bag's contents, such as when you check, fill, or empty the bag. Once known, the counter also follows coal mined directly into an open bag, bonus ore from the Celestial ring and Varrock platebody, and bank container-emptying.
 
 Coal picked up from the ground directly into an open bag cannot be tracked reliably because the game does not expose a safe event for that action.
+
 ## Configuration
 
 The following counter colors can be configured in RuneLite:

--- a/src/main/java/com/coalbagplugin/CoalBag.java
+++ b/src/main/java/com/coalbagplugin/CoalBag.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Adam <Adam@sigterm.info>
  * Copyright (c) 2021 Nick Wolff <nick@wolff.tech>
+ * Copyright (c) 2022 TicTac7x
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,6 +36,7 @@ public class CoalBag
 
 	private static final Pattern BAG_EMPTY_MESSAGE = Pattern.compile("^The coal bag is (?:now\\s)?empty\\.");
 	private static final Pattern BAG_ONE_OR_MANY_MESSAGE = Pattern.compile("^The coal bag (?:still\\s)?contains ([\\d]+|one) pieces? of coal\\.");
+	private static final String EMPTY_ALL_CONTAINERS_MESSAGE = "You empty all of your containers into the bank.";
 
 	private static int storedAmount;
 
@@ -53,6 +55,18 @@ public class CoalBag
 		storedAmount = UNKNOWN_AMOUNT;
 	}
 
+	public static void addAmount(int amount, int maximumAmount)
+	{
+		if (isUnknown() || amount <= 0)
+		{
+			return;
+		}
+
+		final long increasedAmount = (long) storedAmount + amount;
+		final int clampedAmount = (int) Math.min(increasedAmount, (long) maximumAmount);
+		setAmount(Math.max(storedAmount, clampedAmount));
+	}
+
 	public static String getAmount()
 	{
 		return String.valueOf(storedAmount);
@@ -60,6 +74,12 @@ public class CoalBag
 
 	public static void updateAmount(String message)
 	{
+		if (EMPTY_ALL_CONTAINERS_MESSAGE.equals(message))
+		{
+			setEmptyAmount();
+			return;
+		}
+
 		final Matcher emptyMatcher = BAG_EMPTY_MESSAGE.matcher(message);
 		if (emptyMatcher.matches())
 		{

--- a/src/main/java/com/coalbagplugin/CoalBagPlugin.java
+++ b/src/main/java/com/coalbagplugin/CoalBagPlugin.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Adam <Adam@sigterm.info>
  * Copyright (c) 2021 Nick Wolff <nick@wolff.tech>
+ * Copyright (c) 2022 TicTac7x
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +30,9 @@ import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.MenuOptionClicked;
@@ -40,6 +44,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
+import java.util.regex.Pattern;
 
 @Slf4j
 @PluginDescriptor(
@@ -49,6 +54,18 @@ import javax.inject.Inject;
 )
 public class CoalBagPlugin extends Plugin
 {
+	private static final int COAL_BAG_CAPACITY = 27;
+	private static final int SMITHING_CAPE_COAL_BAG_CAPACITY = 36;
+
+	private static final String EMPTY_ALL_CONTAINERS_MESSAGE = "You empty all of your containers into the bank.";
+	private static final String MINE_OPTION = "Mine";
+	private static final String COAL_ROCKS_TARGET = "Coal rocks";
+	private static final String COAL_MINED_MESSAGE = "You manage to mine some coal.";
+
+	private static final Pattern COLOUR_TAG_PATTERN = Pattern.compile("</?col(?:=[^>]*)?>");
+	private static final Pattern BONUS_ORE_MESSAGE = Pattern.compile(
+			"^(?:Your Celestial ring allows you to mine an additional ore\\.|The Varrock platebody enabled you to mine an additional ore\\.)$"
+	);
 
 	@Inject
 	private Client client;
@@ -58,6 +75,8 @@ public class CoalBagPlugin extends Plugin
 
 	@Inject
 	private CoalBagOverlay coalBagOverlay;
+
+	private boolean miningCoal;
 
 	@Provides
 	CoalBagConfig provideConfig(ConfigManager configManager)
@@ -70,20 +89,38 @@ public class CoalBagPlugin extends Plugin
 	{
 		overlayManager.add(coalBagOverlay);
 		CoalBag.setUnknownAmount();
+		miningCoal = false;
 	}
 
 	@Override
 	protected void shutDown()
 	{
 		overlayManager.remove(coalBagOverlay);
+		miningCoal = false;
 	}
 
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
-		if (event.getType() == ChatMessageType.GAMEMESSAGE)
+		if (!isTrackedChatMessageType(event.getType()))
 		{
-			CoalBag.updateAmount(event.getMessage());
+			return;
+		}
+
+		String message = cleanText(event.getMessage());
+		if (!EMPTY_ALL_CONTAINERS_MESSAGE.equals(message) || hasCoalBag())
+		{
+			CoalBag.updateAmount(message);
+		}
+
+		if (hasOpenCoalBag() && COAL_MINED_MESSAGE.equals(message))
+		{
+			CoalBag.addAmount(1, getCoalBagCapacity());
+			miningCoal = true;
+		}
+		else if (miningCoal && hasOpenCoalBag() && BONUS_ORE_MESSAGE.matcher(message).matches())
+		{
+			CoalBag.addAmount(1, getCoalBagCapacity());
 		}
 	}
 
@@ -95,16 +132,64 @@ public class CoalBagPlugin extends Plugin
 		Widget coalBagWidget = client.getWidget(12648450);
 		if (coalBagWidget != null)
 		{
-			CoalBag.updateAmount(coalBagWidget.getText());
+			CoalBag.updateAmount(cleanText(coalBagWidget.getText()));
 		}
 	}
 
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if ("Destroy".equals(event.getMenuOption()))
+		String option = cleanText(event.getMenuOption());
+		String target = cleanText(event.getMenuTarget());
+
+		miningCoal = MINE_OPTION.equals(option) && target.contains(COAL_ROCKS_TARGET);
+
+		if ("Destroy".equals(option) && target.toLowerCase().contains("coal bag"))
 		{
 			CoalBag.setUnknownAmount();
 		}
+	}
+
+	private static boolean isTrackedChatMessageType(ChatMessageType type)
+	{
+		return type == ChatMessageType.GAMEMESSAGE
+				|| type == ChatMessageType.SPAM;
+	}
+
+	private static String cleanText(String text)
+	{
+		if (text == null)
+		{
+			return "";
+		}
+
+		return COLOUR_TAG_PATTERN.matcher(text)
+				.replaceAll("")
+				.replace("<br>", " ")
+				.replace('\u00A0', ' ')
+				.trim();
+	}
+
+	private boolean hasCoalBag()
+	{
+		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+		return inventory != null
+				&& (inventory.contains(ItemID.COAL_BAG_12019) || inventory.contains(ItemID.OPEN_COAL_BAG));
+	}
+
+	private boolean hasOpenCoalBag()
+	{
+		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+		return inventory != null && inventory.contains(ItemID.OPEN_COAL_BAG);
+	}
+
+	private int getCoalBagCapacity()
+	{
+		ItemContainer equipment = client.getItemContainer(InventoryID.EQUIPMENT);
+		boolean smithingCapeEquipped = equipment != null
+				&& (equipment.contains(ItemID.SMITHING_CAPE)
+				|| equipment.contains(ItemID.SMITHING_CAPET)
+				|| equipment.contains(ItemID.MAX_CAPE));
+		return smithingCapeEquipped ? SMITHING_CAPE_COAL_BAG_CAPACITY : COAL_BAG_CAPACITY;
 	}
 }

--- a/src/test/java/com/coalbagplugin/CoalBagTest.java
+++ b/src/test/java/com/coalbagplugin/CoalBagTest.java
@@ -1,0 +1,66 @@
+package com.coalbagplugin;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CoalBagTest
+{
+	@Before
+	public void setUp()
+	{
+		CoalBag.setUnknownAmount();
+	}
+
+	@Test
+	public void updateAmountParsesCoalBagMessages()
+	{
+		CoalBag.updateAmount("The coal bag is empty.");
+		assertTrue(CoalBag.isEmpty());
+
+		CoalBag.updateAmount("The coal bag is now empty.");
+		assertTrue(CoalBag.isEmpty());
+
+		CoalBag.updateAmount("The coal bag contains one piece of coal.");
+		assertEquals("1", CoalBag.getAmount());
+
+		CoalBag.updateAmount("The coal bag still contains one piece of coal.");
+		assertEquals("1", CoalBag.getAmount());
+
+		CoalBag.updateAmount("The coal bag contains 27 pieces of coal.");
+		assertEquals("27", CoalBag.getAmount());
+	}
+
+	@Test
+	public void updateAmountParsesExactEmptyAllContainersMessage()
+	{
+		CoalBag.updateAmount("The coal bag contains 10 pieces of coal.");
+		CoalBag.updateAmount("You empty all of your containers into the bank.");
+		assertTrue(CoalBag.isEmpty());
+
+		CoalBag.updateAmount("The coal bag contains 10 pieces of coal.");
+		CoalBag.updateAmount("You empty all of your containers into the bank. Extra text");
+		assertEquals("10", CoalBag.getAmount());
+	}
+
+	@Test
+	public void addAmountPreservesUnknownAndClampsWithoutReducing()
+	{
+		CoalBag.addAmount(1, 27);
+		assertTrue(CoalBag.isUnknown());
+
+		CoalBag.updateAmount("The coal bag contains 20 pieces of coal.");
+		CoalBag.addAmount(10, 27);
+		assertEquals("27", CoalBag.getAmount());
+
+		CoalBag.updateAmount("The coal bag contains 30 pieces of coal.");
+		CoalBag.addAmount(1, 27);
+		assertEquals("30", CoalBag.getAmount());
+
+		CoalBag.addAmount(-1, 27);
+		assertEquals("30", CoalBag.getAmount());
+	}
+
+}


### PR DESCRIPTION
Tracks coal mined directly into an open bag; tested filling and emptying in different situations and mining with the bag open and closed.

Closes #9

<img width="846" height="631" alt="capture-coal" src="https://github.com/user-attachments/assets/637176de-55ed-4344-8bea-0ff0a1292851" />
